### PR TITLE
Fix status line buffer overflow

### DIFF
--- a/ec.cc
+++ b/ec.cc
@@ -330,9 +330,11 @@ void updateWindows()
     snprintf(statusLine, SCRMAXWD, "----- %c %4s: %-33s",
         command, fileStat, curFileName);
     char* p = statusLine + strlen(statusLine);
-    while (p < statusLine + screenWd - 30)
+    while (p < statusLine + screenWd - 30 && p < statusLine + SCRMAXWD - 1)
         *p++ = ' ';
-    snprintf(p, SCRMAXWD, "buffer=%d [    ,   ] %s %c -----", buffA, insMsg,
+    *p = '\0';
+    size_t remain = SCRMAXWD - (p - statusLine);
+    snprintf(p, remain, "buffer=%d [    ,   ] %s %c -----", buffA, insMsg,
              lEndMsg);
 
     if (bcursPos != lastCursPos)


### PR DESCRIPTION
## Summary
- fix buffer overrun when building the status line

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_684392c009d08332804c60077bc97c5f