### PR TITLE
Harden editor against command injection and buffer-overflow risks

### DIFF
--- a/ec.cc
+++ b/ec.cc
@@ -22,6 +22,7 @@
 #include <sys/wait.h>
 #include <signal.h>
 #include <stdarg.h>
+#include <glob.h>
 
 #include "termp.h"
 #include "ec.h"
@@ -1259,65 +1260,51 @@ void getCommand(const char* msg, bool isFile)
             {
                 // tab-- try to complete a filename
                 *bcursPos = 0;
-                char lsCmd[MAX_LINE];
-                snprintf(lsCmd, MAX_LINE, "ls -dF %s* 2>&1", bstart);
-                fflush(stdout);
-                FILE* ls = popen(lsCmd, "r");
-                if (!ls)
+                glob_t matches;
+                memset(&matches, 0, sizeof(matches));
+                char pattern[MAX_LINE + 4];
+                snprintf(pattern, sizeof(pattern), "%s*", bstart);
+                int g = glob(pattern, GLOB_MARK, 0, &matches);
+                if (g == GLOB_NOSPACE)
                     putchar(CH_BELL);
-                else
+                else if (g == 0 && matches.gl_pathc > 0)
                 {
-                    char* buf = new char[32000];
-                    int n = fread(buf, 1, 32000, ls);
-                    if (!pclose(ls) && n > 0)
+                    int baseLen = bcursPos - bstart;
+                    const char* first = matches.gl_pathv[0];
+                    int firstLen = strlen(first);
+                    if (firstLen >= baseLen &&
+                        strncmp(first, bstart, (size_t)baseLen) == 0)
                     {
-                        int baseLen = bcursPos - bstart;
-                        char* p = buf;
-                        char* addB1 = p + baseLen;
-                        char* addE1 = 0;
-                        char* addB2 = 0;
-                        int col = 0;
-                        int line = 0;
-                        char* base = bstart;
-                        for ( ; *p; p++)
+                        int commonLen = firstLen;
+                        for (size_t i = 1; i < matches.gl_pathc; i++)
                         {
-                            if (col == baseLen)
-                                addB2 = p;
-                            if (!*p || (col < baseLen && *p != *base))
+                            const char* s = matches.gl_pathv[i];
+                            int slen = strlen(s);
+                            if (slen < baseLen ||
+                                strncmp(s, bstart, (size_t)baseLen) != 0)
+                            {
+                                commonLen = baseLen;
                                 break;
-                            if (*p == '\n')
-                            {
-                                if (col <= baseLen)
-                                    break;
-                                char* p1 = addB1;
-                                char* p2 = addB2;
-                                while (*p1 == *p2 && *p1 != '\n')
-                                {
-                                    p1++;
-                                    p2++;
-                                }
-                                if (!addE1 || p1 < addE1)
-                                    addE1 = p1;
-                                col = 0;
-                                base = bstart;
-                                line++;
                             }
-                            else
-                            {
-                                col++;
-                                base++;
-                            }
+                            int j = baseLen;
+                            while (j < commonLen && j < slen &&
+                                s[j] == first[j])
+                                j++;
+                            commonLen = j;
                         }
-                        if (line != 1)
+
+                        if (matches.gl_pathc != 1)
                             putchar(CH_BELL);
-                        if (line > 0)
+
+                        if (commonLen > baseLen)
                         {
-                            int addLen = addE1 - addB1;
-                            insert(bcursPos, addB1, addLen);
+                            int addLen = commonLen - baseLen;
+                            insert(bcursPos, first + baseLen, addLen);
                             bcursPos += addLen;
                         }
                     }
                 }
+                globfree(&matches);
             }
         }
         else if (key < 0x20 || key == CH_RUB)

--- a/ec.h
+++ b/ec.h
@@ -19,6 +19,7 @@
 #ifndef ec_h_
 #define ec_h_
 
+#include <stdio.h>
 #include <string.h>
 
 // standard types and constants
@@ -47,9 +48,23 @@ class TmpName
 
 public:
     TmpName&    operator = (char* name)
-        { strncpy(this->name, name, max_nameLen); return* this; }
+        {
+            if (name)
+                snprintf(this->name, max_nameLen, "%s", name);
+            else
+                this->name[0] = '\0';
+            return *this;
+        }
     TmpName&    operator += (char* s)
-        { strncat(this->name, s, max_nameLen); return* this; }
+        {
+            if (s)
+            {
+                size_t n = strlen(this->name);
+                if (n < max_nameLen - 1)
+                    strncat(this->name, s, max_nameLen - n - 1);
+            }
+            return *this;
+        }
     TmpName();
     TmpName(char* fmt, ...);
     operator char* ()   { return this->name; }

--- a/ecbuf.cc
+++ b/ecbuf.cc
@@ -670,8 +670,7 @@ void writeToFile(const char* fName, const char* fPath, char* start, char* end)
         fclose(fp);
         stat(fPath, &fileStats);
         haveStats = TRUE;
-        strcpy(backupName, ".~");
-        strncat(backupName, fPath, MAX_LINE+9);
+        snprintf(backupName, sizeof(backupName), ".~%s", fPath);
         rename(fPath, backupName);
     }
 

--- a/termx.cc
+++ b/termx.cc
@@ -54,6 +54,7 @@ char            myAB[20];
 
 int             screenHt, screenWd;     // screen dimensions
 
+#ifndef TERMCAPS
 static void copyCap(char* dest, size_t destLen, const char* src)
 {
     if (!src)
@@ -63,6 +64,7 @@ static void copyCap(char* dest, size_t destLen, const char* src)
     }
     snprintf(dest, destLen, "%s", src);
 }
+#endif
 
 // ----------------------------------------------------------------------------
 // Get (new) screen dimensions to screenHt, screenWd.

--- a/termx.cc
+++ b/termx.cc
@@ -54,6 +54,16 @@ char            myAB[20];
 
 int             screenHt, screenWd;     // screen dimensions
 
+static void copyCap(char* dest, size_t destLen, const char* src)
+{
+    if (!src)
+    {
+        dest[0] = '\0';
+        return;
+    }
+    snprintf(dest, destLen, "%s", src);
+}
+
 // ----------------------------------------------------------------------------
 // Get (new) screen dimensions to screenHt, screenWd.
 
@@ -122,15 +132,15 @@ void iTermCaps(termOptStr* termSave)
     setupterm((char*)0, 1, (int*)0);    // terminfo setup
     screenHt = lines;
     screenWd = columns - 1;
-    strcpy(myClrScr, clear_screen);     // just copy strings
-    strcpy(myClrEol, clr_eol);
-    strcpy(myCurAdr, cursor_address);
-    strcpy(myBold, enter_bold_mode);
-    strcpy(myRev, enter_reverse_mode);
-    strcpy(myUnder, enter_underline_mode);
-    strcpy(myNorm, exix_attribute_mode);
-    strcpy(myAF, set_a_foreground);
-    strcpy(myAB, set_a_background);
+    copyCap(myClrScr, sizeof(myClrScr), clear_screen); // just copy strings
+    copyCap(myClrEol, sizeof(myClrEol), clr_eol);
+    copyCap(myCurAdr, sizeof(myCurAdr), cursor_address);
+    copyCap(myBold, sizeof(myBold), enter_bold_mode);
+    copyCap(myRev, sizeof(myRev), enter_reverse_mode);
+    copyCap(myUnder, sizeof(myUnder), enter_underline_mode);
+    copyCap(myNorm, sizeof(myNorm), exix_attribute_mode);
+    copyCap(myAF, sizeof(myAF), set_a_foreground);
+    copyCap(myAB, sizeof(myAB), set_a_background);
     reset_shell_mode();                 // and restore term
 #endif
 


### PR DESCRIPTION
### Motivation
- Eliminate a shell-invocation in interactive filename completion to remove a command-injection attack surface when completing user-typed file fragments.
- Replace unsafe, unbounded string operations used for terminal capability handling, temporary names, and backup path construction to reduce buffer-overflow and truncation risks.

### Description
- Replaced the `popen("ls ...")` based filename tab-completion in `getCommand()` with `glob()`-based matching and safe prefix/common-prefix insertion, and added `#include <glob.h>`; handles `GLOB_NOSPACE` and calls `globfree()` after use (`ec.cc`).
- Added a bounded `copyCap()` helper to safely copy terminfo capability strings and handle null sources, replacing several raw `strcpy()` calls into fixed-size buffers (`termx.cc`).
- Constructed backup filenames using bounded `snprintf()` instead of `strcpy`/`strncat` to avoid path overflow (`ecbuf.cc`).
- Made `TmpName` assignment and append operators null-aware and length-bounded using `snprintf`/`strncat` checks, and added a required `#include <stdio.h>` in the header (`ec.h`).

### Testing
- Built the project with `make -j4` and the build completed successfully producing the binary; compiler warnings are pre-existing and not introduced by these changes.
- No automated unit tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69daeacbc430833293f7851646aafd84)